### PR TITLE
Add Docker support for running backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.env
+uploads

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:18-alpine
+
+# Create app directory
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm install --production
+
+# Bundle app source
+COPY . .
+
+# Ensure upload directory exists
+RUN mkdir -p uploads
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ Starter Express.js backend for the DocDone SaaS application. It accepts document
    ```
    The server listens on `http://localhost:3000` by default.
 
+## Running with Docker
+1. Build the image:
+   ```bash
+   docker build -t docdone .
+   ```
+2. Copy the example environment file and add your [OpenAI API key](https://platform.openai.com/account/api-keys):
+   ```bash
+   cp .env.example .env
+   # edit .env and set OPENAI_API_KEY
+   ```
+3. Start the container:
+   ```bash
+   docker run --env-file .env -p 3000:3000 docdone
+   ```
+   The server listens on `http://localhost:3000` by default.
+
 ## Deploying to Render.com
 1. Push this repository to GitHub.
 2. In the Render dashboard, create a **New Web Service** and connect it to the GitHub repo.


### PR DESCRIPTION
## Summary
- add Dockerfile and .dockerignore to containerize the service
- document Docker build and run steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689286fdd2108320ad3d62d7f8cc0dad