### PR TITLE
Add basic full-stack demo with file analysis and generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,44 @@
-# DocDone Backend
+# DocDone Full Stack Demo
 
-Starter Express.js backend for the DocDone SaaS application. It accepts document uploads, analyzes content with OpenAI, and runs transformation tasks. The service responds with friendly, branded messages to make interaction simple and pleasant.
+A simple Node.js + Express backend with a static HTML/JS frontend. Users upload a document, the server analyzes it with OpenAI, and suggests transformations. Selecting a suggestion generates new content.
 
 ## Features
-- **/upload** – upload PDF, DOCX, TXT, or CSV files
-- **/analyze** – summarize an uploaded file and suggest output formats
-- **/generate** – transform the file based on a chosen goal
-- `.env` support for storing the OpenAI key
-- Ready to deploy to Render.com
+- Upload `.pdf`, `.docx`, `.txt`, or `.xlsx` files
+- Summarize files using OpenAI's `gpt-4o` model
+- Suggest possible outputs with fake cost estimates
+- Generate the selected output with optional extra notes
+- Static frontend using Tailwind CSS via CDN
+- Ready for deployment on [Render.com](https://render.com)
 
 ## Running Locally
-1. Install dependencies:
+1. Install dependencies
    ```bash
    npm install
    ```
-2. Copy the example environment file and add your [OpenAI API key](https://platform.openai.com/account/api-keys):
+2. Configure environment
    ```bash
    cp .env.example .env
-   # edit .env and set OPENAI_API_KEY
+   # set OPENAI_API_KEY in .env
    ```
-3. Start the server:
+3. Start the server
    ```bash
    npm start
    ```
-   The server listens on `http://localhost:3000` by default.
+4. Visit `http://localhost:3000` and upload a document.
 
-## Deploying to Render.com
-1. Push this repository to GitHub.
-2. In the Render dashboard, create a **New Web Service** and connect it to the GitHub repo.
-3. Use `npm install` as the build command and `npm start` as the start command.
-4. Add the `OPENAI_API_KEY` environment variable in the Render service settings.
-5. Deploy; Render will build and serve your backend automatically.
-
-You can also deploy via Render's [Blueprints](https://render.com/docs/blueprint-spec) using the included `render.yaml` file.
-
-## Future Frontend Integration
-When connecting a frontend, you may need CORS support. Install the `cors` package and add:
-```javascript
-const cors = require('cors');
-app.use(cors());
-```
-to `src/index.js`.
+## Deployment to Render
+1. Push the repository to GitHub
+2. In Render, create a new web service and connect the repo
+3. Use `npm install` as the build command and `npm start` as the start command
+4. Set the `OPENAI_API_KEY` environment variable
+5. Deploy
 
 ## Folder Structure
 ```
-docdone-backend
-├── src
-│   └── index.js
-├── .env.example
-├── .gitignore
-├── package.json
-└── README.md
+public/       - frontend HTML/JS
+routes/       - API routes
+controllers/  - request handlers
+utils/        - helper utilities (e.g., extractText)
+uploads/      - temporary file storage (ignored by git)
+src/          - server entry point
 ```
-
-## License
-MIT

--- a/controllers/analyzeController.js
+++ b/controllers/analyzeController.js
@@ -1,0 +1,40 @@
+const path = require('path');
+const fs = require('fs');
+const { extractText } = require('../utils/extractText');
+const { OpenAI } = require('openai');
+
+// Initialize OpenAI client using API key from environment
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+// Analyze an uploaded file: summarize and suggest possible transformations
+exports.analyzeFile = async (req, res) => {
+  try {
+    const { fileId } = req.body;
+    if (!fileId) return res.status(400).json({ error: 'fileId required' });
+    const filePath = path.join(__dirname, '..', 'uploads', fileId);
+    if (!fs.existsSync(filePath)) return res.status(404).json({ error: 'File not found' });
+
+    const text = await extractText(filePath);
+    const prompt = `Summarize the following document in a few sentences:\n\n${text}`;
+
+    // The OpenAI API generates a concise summary of the document
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const summary = completion.choices[0].message.content.trim();
+
+    // Static suggestions with fake cost estimates (USD)
+    const suggestions = [
+      { name: 'Presentation', cost: 0.02 },
+      { name: 'Summary', cost: 0.01 },
+      { name: 'Calendar', cost: 0.015 },
+      { name: 'Social posts', cost: 0.012 },
+    ];
+
+    res.json({ summary, suggestions });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Analysis failed' });
+  }
+};

--- a/controllers/generateController.js
+++ b/controllers/generateController.js
@@ -1,0 +1,37 @@
+const path = require('path');
+const fs = require('fs');
+const { extractText } = require('../utils/extractText');
+const { OpenAI } = require('openai');
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+// Transform the uploaded file into a new output using GPT
+exports.generateOutput = async (req, res) => {
+  try {
+    const { fileId, task, notes } = req.body;
+    if (!fileId || !task) {
+      return res.status(400).json({ error: 'fileId and task required' });
+    }
+    const filePath = path.join(__dirname, '..', 'uploads', fileId);
+    if (!fs.existsSync(filePath)) return res.status(404).json({ error: 'File not found' });
+
+    const text = await extractText(filePath);
+    const prompt = `Create a ${task} from the following document. Extra notes: ${notes || 'none'}\n\n${text}`;
+
+    // OpenAI generates the requested transformation
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const result = completion.choices[0].message.content.trim();
+
+    res.json({
+      result,
+      blurb: `Your ${task} is ready.`,
+      cost: 0.05, // fake cost estimate
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Generation failed' });
+  }
+};

--- a/controllers/uploadController.js
+++ b/controllers/uploadController.js
@@ -1,0 +1,11 @@
+// Handle uploaded file and respond with its metadata
+exports.uploadFile = (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'No file uploaded' });
+  }
+  res.json({
+    message: 'File uploaded successfully.',
+    fileId: req.file.filename,
+    originalName: req.file.originalname,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "mammoth": "^1.6.0",
     "multer": "^1.4.5-lts.1",
     "openai": "^4.0.0",
-    "pdf-parse": "^1.1.1"
+    "pdf-parse": "^1.1.1",
+    "cors": "^2.8.5",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>DocDone</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-8">
+  <h1 class="text-2xl font-bold mb-4">DocDone Demo</h1>
+  <input id="file" type="file" class="mb-4 border p-2" />
+  <div id="summary" class="my-4"></div>
+  <div id="suggestions" class="flex flex-wrap gap-2 mb-4"></div>
+  <textarea id="notes" class="border p-2 w-full mb-2" placeholder="Extra notes..."></textarea>
+  <input id="logo" type="file" class="mb-4 border p-2" />
+  <button id="generate" class="bg-blue-500 text-white px-4 py-2 rounded">Generate Output</button>
+  <div id="result" class="mt-4 whitespace-pre-wrap"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,56 @@
+const fileInput = document.getElementById('file');
+const suggestionsDiv = document.getElementById('suggestions');
+let fileId = null;
+let selected = null;
+
+fileInput.addEventListener('change', async () => {
+  const file = fileInput.files[0];
+  if (!file) return;
+  const form = new FormData();
+  form.append('file', file);
+  const uploadRes = await fetch('/api/upload', { method: 'POST', body: form });
+  const uploadData = await uploadRes.json();
+  fileId = uploadData.fileId;
+
+  const analyzeRes = await fetch('/api/analyze', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ fileId })
+  });
+  const analyzeData = await analyzeRes.json();
+  document.getElementById('summary').innerText = analyzeData.summary;
+  suggestionsDiv.innerHTML = '';
+  analyzeData.suggestions.forEach(s => {
+    const btn = document.createElement('button');
+    btn.textContent = `${s.name} ($${s.cost})`;
+    btn.className = 'bg-gray-200 px-2 py-1 rounded';
+    btn.addEventListener('click', () => {
+      selected = s.name;
+      Array.from(suggestionsDiv.children).forEach(c => c.classList.remove('bg-blue-500', 'text-white'));
+      btn.classList.add('bg-blue-500', 'text-white');
+    });
+    suggestionsDiv.appendChild(btn);
+  });
+});
+
+const generateBtn = document.getElementById('generate');
+generateBtn.addEventListener('click', async () => {
+  if (!fileId || !selected) return;
+  const notes = document.getElementById('notes').value;
+  const res = await fetch('/api/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ fileId, task: selected, notes })
+  });
+  const data = await res.json();
+  const resultDiv = document.getElementById('result');
+  resultDiv.textContent = data.result + `\n\nCost: $${data.cost}`;
+  const blob = new Blob([data.result], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${selected}.txt`;
+  link.textContent = 'Download result';
+  resultDiv.appendChild(document.createElement('br'));
+  resultDiv.appendChild(link);
+});

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+const uploadController = require('../controllers/uploadController');
+const analyzeController = require('../controllers/analyzeController');
+const generateController = require('../controllers/generateController');
+
+const router = express.Router();
+
+// Ensure uploads directory exists
+const uploadDir = path.join(__dirname, '..', 'uploads');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir);
+}
+
+// Multer storage configuration
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => cb(null, uploadDir),
+  filename: (req, file, cb) => {
+    const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    cb(null, unique + path.extname(file.originalname));
+  }
+});
+
+const allowedExt = ['.pdf', '.docx', '.txt', '.xlsx'];
+const upload = multer({
+  storage,
+  fileFilter: (req, file, cb) => {
+    const ext = path.extname(file.originalname).toLowerCase();
+    if (allowedExt.includes(ext)) cb(null, true);
+    else cb(new Error('DocDone only accepts PDF, DOCX, TXT, or XLSX files.'));
+  }
+});
+
+router.post('/upload', upload.single('file'), uploadController.uploadFile);
+router.post('/analyze', analyzeController.analyzeFile);
+router.post('/generate', generateController.generateOutput);
+
+module.exports = router;

--- a/src/index.js
+++ b/src/index.js
@@ -1,134 +1,31 @@
 const express = require('express');
-const multer = require('multer');
 const path = require('path');
-const fs = require('fs');
-const pdfParse = require('pdf-parse');
-const mammoth = require('mammoth');
-const { OpenAI } = require('openai');
 require('dotenv').config();
 
 const app = express();
 app.use(express.json());
 
-// basic health check route
-app.get('/', (req, res) => {
-  res.send('DocDone backend is running. Upload files via POST /upload.');
-});
-
-// ensure uploads directory exists
-const uploadDir = path.join(__dirname, '..', 'uploads');
-if (!fs.existsSync(uploadDir)) {
-  fs.mkdirSync(uploadDir);
-}
-
-const storage = multer.diskStorage({
-  destination: (req, file, cb) => cb(null, uploadDir),
-  filename: (req, file, cb) => {
-    const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
-    const ext = path.extname(file.originalname);
-    cb(null, unique + ext);
-  },
-});
-
-const allowedExt = ['.pdf', '.docx', '.txt', '.csv'];
-const upload = multer({
-  storage,
-  fileFilter: (req, file, cb) => {
-    const ext = path.extname(file.originalname).toLowerCase();
-    if (allowedExt.includes(ext)) cb(null, true);
-    else cb(new Error('DocDone supports only PDF, DOCX, TXT, and CSV files.'));
-  },
-});
-
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-
-async function extractText(filePath) {
-  const ext = path.extname(filePath).toLowerCase();
-  if (ext === '.pdf') {
-    const dataBuffer = fs.readFileSync(filePath);
-    const data = await pdfParse(dataBuffer);
-    return data.text;
-  }
-  if (ext === '.docx') {
-    const data = await mammoth.extractRawText({ path: filePath });
-    return data.value;
-  }
-  if (ext === '.txt' || ext === '.csv') {
-    return fs.readFileSync(filePath, 'utf8');
-  }
-  return '';
-}
-
-app.post('/upload', upload.single('file'), (req, res) => {
-  if (!req.file) {
-    return res.status(400).json({ error: 'No file uploaded' });
-  }
-  res.json({
-    message: 'File uploaded successfully to DocDone.',
-    fileId: req.file.filename,
-    originalName: req.file.originalname,
+// Attempt to use the cors package; fall back to manual headers if unavailable
+let cors;
+try {
+  cors = require('cors');
+  app.use(cors());
+} catch (e) {
+  app.use((req, res, next) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    next();
   });
-});
+}
 
-app.post('/analyze', async (req, res) => {
-  try {
-    const { fileId } = req.body;
-    if (!fileId) return res.status(400).json({ error: 'fileId required' });
-    const filePath = path.join(uploadDir, fileId);
-    if (!fs.existsSync(filePath)) return res.status(404).json({ error: 'File not found' });
-    const text = await extractText(filePath);
-    const prompt = `Summarize the following text and suggest possible output formats (e.g., presentation, calendar, summary):\n\n${text}`;
-    const completion = await openai.chat.completions.create({
-      model: 'gpt-3.5-turbo',
-      messages: [{ role: 'user', content: prompt }],
-    });
-    res.json({
-      message: 'Analysis complete.',
-      analysis: completion.choices[0].message.content,
-    });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'DocDone could not analyze your file. Please try again later.' });
-  }
-});
+// Serve static frontend files
+app.use(express.static(path.join(__dirname, '..', 'public')));
 
-app.post('/generate', async (req, res) => {
-  try {
-    const { fileId, goal } = req.body;
-    if (!fileId || !goal) {
-      return res.status(400).json({ error: 'fileId and goal required' });
-    }
-    const filePath = path.join(uploadDir, fileId);
-    if (!fs.existsSync(filePath)) return res.status(404).json({ error: 'File not found' });
-    const text = await extractText(filePath);
-    const prompt = `Transform the following text into a ${goal}:\n\n${text}`;
-    const completion = await openai.chat.completions.create({
-      model: 'gpt-3.5-turbo',
-      messages: [{ role: 'user', content: prompt }],
-    });
-    res.json({
-      message: `Generated ${goal} successfully.`,
-      result: completion.choices[0].message.content,
-    });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'DocDone could not complete this request. Please try again later.' });
-  }
-});
+// API routes handling upload/analyze/generate
+const apiRoutes = require('../routes/api');
+app.use('/api', apiRoutes);
 
 const PORT = process.env.PORT || 3000;
-app.use((err, req, res, next) => {
-  if (err) {
-    if (err.message && err.message.includes('DocDone supports only')) {
-      return res.status(400).json({ error: err.message });
-    }
-    console.error(err);
-    return res.status(500).json({ error: 'Unexpected server error. Please try again later.' });
-  }
-  next();
-});
-
 app.listen(PORT, () => {
-  console.log(`DocDone backend listening on port ${PORT}. Submit files via POST /upload.`);
+  console.log(`DocDone backend listening on port ${PORT}`);
 });
-

--- a/utils/extractText.js
+++ b/utils/extractText.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const pdfParse = require('pdf-parse');
+const mammoth = require('mammoth');
+let xlsx;
+try {
+  xlsx = require('xlsx');
+} catch (e) {
+  xlsx = null;
+}
+
+// Read a file and return plain text regardless of extension
+async function extractText(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.pdf') {
+    const dataBuffer = fs.readFileSync(filePath);
+    const data = await pdfParse(dataBuffer);
+    return data.text;
+  }
+  if (ext === '.docx') {
+    const data = await mammoth.extractRawText({ path: filePath });
+    return data.value;
+  }
+  if (ext === '.txt') {
+    return fs.readFileSync(filePath, 'utf8');
+  }
+  if (ext === '.xlsx') {
+    if (!xlsx) return '';
+    const workbook = xlsx.readFile(filePath);
+    let text = '';
+    workbook.SheetNames.forEach(name => {
+      text += xlsx.utils.sheet_to_csv(workbook.Sheets[name]);
+    });
+    return text;
+  }
+  return '';
+}
+
+module.exports = { extractText };


### PR DESCRIPTION
## Summary
- add express routes and controllers for uploading, analyzing, and generating documents via OpenAI
- include static Tailwind-based frontend for uploading files and selecting AI-generated suggestions
- provide utilities for text extraction and add CORS/static middleware in server entry point

## Testing
- `npm test`
- `OPENAI_API_KEY=key node src/index.js & sleep 1; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_68928910b1f8832090db860e07db6a2d