### PR TITLE
feat: simplify OpenAI key usage in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:18-alpine
 
+# Allow passing the OpenAI API key at build or run time
+ARG OPENAI_API_KEY
+ENV OPENAI_API_KEY=${OPENAI_API_KEY}
+
 # Create app directory
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -30,16 +30,18 @@ Starter Express.js backend for the DocDone SaaS application. It accepts document
    ```bash
    docker build -t docdone .
    ```
-2. Copy the example environment file and add your [OpenAI API key](https://platform.openai.com/account/api-keys):
+2. Start the container and pass your [OpenAI API key](https://platform.openai.com/account/api-keys):
+   ```bash
+   docker run -e OPENAI_API_KEY=your_openai_api_key -p 3000:3000 docdone
+   ```
+   The server listens on `http://localhost:3000` by default.
+
+   Alternatively, you can still use an environment file:
    ```bash
    cp .env.example .env
    # edit .env and set OPENAI_API_KEY
-   ```
-3. Start the container:
-   ```bash
    docker run --env-file .env -p 3000:3000 docdone
    ```
-   The server listens on `http://localhost:3000` by default.
 
 ## Deploying to Render.com
 1. Push this repository to GitHub.


### PR DESCRIPTION
## Summary
- allow passing the OpenAI key into the Docker image via build args or runtime env vars
- document how to run the container with OPENAI_API_KEY without needing a .env file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892b34d87288320969be5848a93a127